### PR TITLE
improves local test setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 coverage/
+yarn.lock
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Change case of object and arrays",
   "main": "index.js",
   "scripts": {
-    "test": "make coveralls"
+    "test": "make coveralls",
+    "test_local": "make test"
   },
   "repository": {
     "type": "git",
@@ -28,6 +29,7 @@
   "devDependencies": {
     "chai": "^3.2.0",
     "coveralls": "^2.11.4",
+    "istanbul": "^0.4.5",
     "mocha": "^2.2.5"
   }
 }


### PR DESCRIPTION
* first the testsuite was complaining about `istanbul` not being installed, so I added it to the package.json as a dev dependency
* then coveralls was giving me an error message because it tried to post coverage information, but there is no token in the repo.  That's why I added a new npm script `test_local` to let the tests run locally without talking to coveralls.
* finally I added lockfiles to the `.gitignore`